### PR TITLE
changed main entrypoint in package.json to source file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leaflet.featuregroup.subgroup",
   "version": "0.1.2",
   "description": "Creates a Leaflet Feature Group that adds its child layers into a parent group when added to a map",
-  "main": "leaflet.featuregroup.subgroup.js",
+  "main": "leaflet.featuregroup.subgroup-src.js",
   "files": [
     "leaflet.featuregroup.subgroup-src.js",
     "leaflet.featuregroup.subgroup.js"


### PR DESCRIPTION
My build process throws errors like crazy after installing the package with npm, because the main entrypoint in your package.json points to a file that's obviously not there.
